### PR TITLE
Modify first name parsing logic & optimize queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shinetext/nova",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "engines": {
     "node": "v8.10"
   },

--- a/src/helper.js
+++ b/src/helper.js
@@ -34,7 +34,7 @@ const generateReferralCode = async (data, db, wordList = ADJECTIVES) => {
   const adjective = `${wordList[Math.floor(Math.random() * wordList.length)]}`;
   const name = formatName(data.first_name);
 
-  const condition = `%${adjective}-${name}%`;
+  const condition = `${adjective}-${name}%`;
   let count;
 
   // Get row count of users who share the same adj-name base in referral code

--- a/src/helper.js
+++ b/src/helper.js
@@ -1,16 +1,24 @@
 const ADJECTIVES = require('./constants/adjectives');
 
 const formatName = (name) => {
+
+  // If no name is provided, or
+  // if name contains unicode chars, ie. non-latin-based names,
+  // default to 'shine'
   if (!name || name.indexOf('?') !== -1) {
     return 'shine';
   }
-  const parsed = name
-    .trim()
-    .replace(/[\W_]/g, '-') // Replace non-alphanumeric chars with -
-    .replace(/\-\-+/g, '-') // Consolidate multiple hyphens
-    .replace(/(^-)|(-$)/g, ""); // Remove leading & trailing hypens
 
-  return parsed.toLowerCase();
+  const parsed = name
+    .trim() // Trim any leading & trailing white space
+    .split(' ')[0] // Get only 1st part of first name if multiple words in name
+    .replace(/[\W_\d]/g, '') // Strip away non-alphanumeric chars + digits
+    .toLowerCase(); // Standardize casing
+
+  if (parsed) {
+    return parsed;
+  }
+  return 'shine';
 };
 
 /**

--- a/src/helper.js
+++ b/src/helper.js
@@ -34,7 +34,7 @@ const generateReferralCode = async (data, db, wordList = ADJECTIVES) => {
   const adjective = `${wordList[Math.floor(Math.random() * wordList.length)]}`;
   const name = formatName(data.first_name);
 
-  const condition = `${adjective}-${name}%`;
+  const condition = `${adjective}-${name}-%`;
   let count;
 
   // Get row count of users who share the same adj-name base in referral code

--- a/src/index.js
+++ b/src/index.js
@@ -96,18 +96,18 @@ const getReferralCount = async (user, db) => {
     countQuery = `
         SELECT count(*) AS count
         FROM ${process.env.DB_REFERRALS_TABLE}
-        WHERE referred_by = ?
-      )`;
+        WHERE referred_by = ?`;
   }
 
   try {
-    const count = await db.queryAsync(countQuery, [
+    const results = await db.queryAsync(countQuery, [
       `${user.v2_code}`,
       `${user.v1_code}`,
     ]);
+    return results[0].count;
 
-    return count;
   } catch (err) {
+    console.log(err);
     throw new Error('An error occurred getting referral count: ', err);
   }
 };

--- a/test/helper.test.js
+++ b/test/helper.test.js
@@ -8,19 +8,48 @@ const {
 let mockDb;
 
 describe('#formatName', () => {
-  it('should handle special char ', () => {
-    expect(formatName('d.j.   khaLid.')).to.equal('d-j-khalid');
-    expect(formatName('d.j.   kha$%#Lid.')).to.equal('d-j-kha-lid');
-    expect(formatName('sharon dev')).to.equal('sharon-dev');
-    expect(formatName('')).to.equal('shine');
-    expect(formatName()).to.equal('shine');
-  });
 
-  it('should replace ???? with shine', () => {
+  it('should replace any names that contain ???? with `shine`', () => {
     expect(formatName('??????#Sally?. .')).to.equal('shine');
+    expect(formatName('?')).to.equal('shine');
   });
 
-})
+  it('should default to `shine` if no first name is provided', () => {
+    expect(formatName()).to.equal('shine');
+    expect(formatName('')).to.equal('shine');
+    expect(formatName('   ')).to.equal('shine');
+  })
+
+  it('should trim leading & trailing white space ', () => {
+    expect(formatName('  dj ')).to.equal('dj');
+  });
+
+  it('should only use 1st part of the name if there are multiple parts in a first name separated by whitespace', () => {
+    expect(formatName('  Ann Marie Josephine')).to.equal('ann');
+    expect(formatName('  Angel Grace Ariel Caroline McWaters')).to.equal('angel');
+    expect(formatName(`d 'mjust  `)).to.equal('d');
+    expect(formatName(`  An'gel Grace'`)).to.equal('angel');
+  });
+
+  it('should strip away any numbers and special chars including punctuation marks', () => {
+    expect(formatName('d.j.')).to.equal('dj');
+    expect(formatName('d.j.   khaLid.')).to.equal('dj');
+    expect(formatName(`d'Angelo`)).to.equal('dangelo');
+    expect(formatName('kha$%#Lid.')).to.equal('khalid');
+    expect(formatName('O`neil!#grace$%&*%^@&*)-=953')).to.equal('oneilgrace');
+  });
+
+  it('should default to `shine` if the name is an empty string after parsing', () => {
+    expect(formatName('   ')).to.equal('shine');
+    expect(formatName('#%^((**))   ')).to.equal('shine');
+    expect(formatName('....')).to.equal('shine');
+    expect(formatName('/')).to.equal('shine');
+    expect(formatName(`' `)).to.equal('shine');
+    expect(formatName(':)')).to.equal('shine');
+  })
+});
+
+
 describe('#generateReferralCode', () => {
   let mockDb, userData, randomizeList;
 


### PR DESCRIPTION
### What's this PR do?
Modify first name parsing logic & optimize queries

### How was this tested? How should this be reviewed?
- `npm run test` for name parsing updates
- a few manual queries to photon prod read replica seems to indicate the modified LIKE query is 3-4 times faster. Without a leading wildcard, can take advantage of the index on that column.

